### PR TITLE
do not be the actor in lazy do if threshold is not passed

### DIFF
--- a/singleflight.go
+++ b/singleflight.go
@@ -39,16 +39,14 @@ func (c *call) Do(ctx context.Context, fn func() error) error {
 func (c *call) LazyDo(threshold time.Duration, fn func() error) {
 	c.mu.Lock()
 	ch := c.ch
-	if ch != nil {
+	if ch != nil || time.Now().Before(c.ts.Add(threshold)) {
 		c.mu.Unlock()
 		return
 	}
 	ch = make(chan struct{})
 	c.ch = ch
 	c.cn++
-	ts := c.ts
 	c.mu.Unlock()
-	time.Sleep(time.Until(ts.Add(threshold)))
 	go c.do(ch, fn)
 }
 


### PR DESCRIPTION
`LazyDo` allows an action to be performed lazily every `threshold` seconds. It does this by allowing a single caller to perform the action. If the action has been performed within the last` threshold` that caller sleeps until the threshold has elapsed since last action. This guarantees that if a user has called `LazyDo`, the action **will** happen within the next `threshold`.

However, This can cause the caller of `LazyDo` to wait for up to `threshold` if the action was just called. Notably, this can cause a request to a failed server to wait for up to the threshold of 1 second when handling connection closed errors.

Instead, we can skip the action anytime we have not reached the threshold and only take the action if more than the threshold has passed.

**Note:** This breaks the invariant that if `LazyDo` is called and no one is currently performing the action, the action will eventually take place.